### PR TITLE
Generate the fs index save too (17.0.0 brick issue)

### DIFF
--- a/EmmcHaccGen/LibEmmcHaccGen.cs
+++ b/EmmcHaccGen/LibEmmcHaccGen.cs
@@ -196,11 +196,14 @@ public class LibEmmcHaccGen
         if (dumpImkvdb)
             ncm_imkvdb.DumpToFile($"{path}/data.arc");
 
-        WriteSave(path, new ProgramId(0x8000000000000120), new Dictionary<string, byte[]>(){
+        var ncm_saveid = new ProgramId(0x8000000000000120);
+        WriteSave(path, ncm_saveid, new Dictionary<string, byte[]>(){
             {"/meta/imkvdb.arc", ncm_imkvdb.Result}
         }, useV5Save);
+
+        // build the fs save index imkvdb, for now this only contains the ncm content index save
         UInt64 save_size = (UInt64)new FileInfo($"{path}/SYSTEM/save/8000000000000120").Length;
-        Imen imen = new Imen(new ProgramId(0x8000000000000000), save_size);
+        Imen imen = new Imen(ncm_saveid, save_size);
         Imkv fs_save_index = new Imkv(new List<Imen>(){imen});
 
         WriteSave(path, new ProgramId(0x8000000000000000), new Dictionary<string, byte[]>(){

--- a/EmmcHaccGen/imkv/Imen.cs
+++ b/EmmcHaccGen/imkv/Imen.cs
@@ -4,9 +4,45 @@ using System.Linq;
 using EmmcHaccGen.nca;
 using EmmcHaccGen.cnmt;
 using LibHac.Tools.Ncm;
+using LibHac.Ncm;
 
 namespace EmmcHaccGen.imkv
 {
+    class SaveDataAttribute {
+        ProgramId saveid;
+
+        public SaveDataAttribute(ProgramId saveid) {
+            this.saveid = saveid;
+        }
+
+        public List<byte> ToBytes() {
+            byte[] ret = new byte[0x40];
+
+            Buffer.BlockCopy(ret, 0x18, BitConverter.GetBytes(saveid.Value), 0, 8);
+
+            return ret.ToList();
+        }
+    }
+
+    class SaveImenValue {
+        ProgramId saveid;
+        UInt64 save_size;
+
+        public SaveImenValue(ProgramId saveid, UInt64 save_size) {
+            this.saveid = saveid;
+            this.save_size = save_size;
+        }
+
+        public List<byte> ToBytes() {
+            byte[] ret = new byte[0x40];
+
+            Buffer.BlockCopy(ret, 0x0, BitConverter.GetBytes(saveid.Value), 0, 8);
+            Buffer.BlockCopy(ret, 0x8, BitConverter.GetBytes(save_size), 0, 8);
+
+            return ret.ToList();
+        }
+    }
+
     class Imen
     {
         // TODO: Turn to read-only properties
@@ -38,6 +74,13 @@ namespace EmmcHaccGen.imkv
             this.pair = pair;
             this.Gen();
         }
+        public Imen(ProgramId saveid, UInt64 save_size) {
+            this.key = new SaveDataAttribute(saveid).ToBytes();
+            this.value = new SaveImenValue(saveid, save_size).ToBytes();
+            bytes = new List<byte>();
+            pair = new List<NcaFile>();
+            this.Gen();
+        }
 
         public void Gen()
         {
@@ -46,8 +89,10 @@ namespace EmmcHaccGen.imkv
             bytes.Add(0x45);
             bytes.Add(0x4E);
 
-            GenKey();
-            GenValue();
+            if (key.Count() == 0 || value.Count() == 0) {
+                GenKey();
+                GenValue();
+            }
 
             bytes.AddRange(BitConverter.GetBytes((UInt32)key.Count));
             bytes.AddRange(BitConverter.GetBytes((UInt32)value.Count));

--- a/EmmcHaccGen/imkv/Imen.cs
+++ b/EmmcHaccGen/imkv/Imen.cs
@@ -18,7 +18,7 @@ namespace EmmcHaccGen.imkv
         public List<byte> ToBytes() {
             byte[] ret = new byte[0x40];
 
-            Buffer.BlockCopy(ret, 0x18, BitConverter.GetBytes(saveid.Value), 0, 8);
+            Buffer.BlockCopy(BitConverter.GetBytes(saveid.Value), 0, ret, 0x18, 8);
 
             return ret.ToList();
         }
@@ -36,8 +36,8 @@ namespace EmmcHaccGen.imkv
         public List<byte> ToBytes() {
             byte[] ret = new byte[0x40];
 
-            Buffer.BlockCopy(ret, 0x0, BitConverter.GetBytes(saveid.Value), 0, 8);
-            Buffer.BlockCopy(ret, 0x8, BitConverter.GetBytes(save_size), 0, 8);
+            Buffer.BlockCopy(BitConverter.GetBytes(saveid.Value), 0, ret, 0, 8);
+            Buffer.BlockCopy(BitConverter.GetBytes(save_size), 0, ret, 0x8, 8);
 
             return ret.ToList();
         }

--- a/EmmcHaccGen/imkv/Imkv.cs
+++ b/EmmcHaccGen/imkv/Imkv.cs
@@ -9,8 +9,8 @@ namespace EmmcHaccGen.imkv
 {
     class Imkv
     {
-        private NcaIndexer _indexer;
-        private List<string> _skipTitles;
+        private NcaIndexer? _indexer;
+        private List<string>? _skipTitles;
         public byte[] Result { get; private set; }
         
         public Imkv(NcaIndexer ncaIndex, List<string>? skipTitles = null)
@@ -19,9 +19,12 @@ namespace EmmcHaccGen.imkv
             _skipTitles = skipTitles ?? new();
             Result = Build();
         }
-        
-        public byte[] Build()
-        {
+
+        public Imkv(List<Imen> imens) {
+            Result = Imkv.BytesFromImens(imens);
+        }
+
+        public static byte[] BytesFromImens(List<Imen> imens) {
             List<byte> bytes = new();
             
             bytes.Add(0x49); // Spells out IMKV
@@ -34,20 +37,25 @@ namespace EmmcHaccGen.imkv
             bytes.Add(0x0);
             bytes.Add(0x0);
 
-            List<Imen> imens = new();
-            
-            foreach(var entry in _indexer.SortedFiles.Where(x => !_skipTitles.Contains(x.Key)))
-            {
-                imens.Add(new Imen(entry.Value));
-            }
-            
             bytes.AddRange(BitConverter.GetBytes((uint)imens.Count));
             foreach (var single in imens)
             {
                 bytes.AddRange(single.bytes);
             }
 
-            return bytes.ToArray();
+            return bytes.ToArray();  
+        }
+        
+        public byte[] Build()
+        {
+            List<Imen> imens = new();
+            
+            foreach(var entry in _indexer!.SortedFiles.Where(x => !_skipTitles!.Contains(x.Key)))
+            {
+                imens.Add(new Imen(entry.Value));
+            }
+
+            return Imkv.BytesFromImens(imens).ToArray();
         }
 
         public void DumpToFile(string path)


### PR DESCRIPTION
While atmosphere fixes the issue it's still good if we don't cause potential timebomb bricks for people who might use this to wipe a console before selling it off, likely to someone who is not aware of how to fix it. 

I haven't tested it on console yet (the generated files look fine) because i'd need to compile atmosphere for that with the workaround commit reverted and at the time of me trying it didn't seem to compile.

Sending it in as a draft until someone (or I) tests it on console and so I don't forget about it again like the last couple of days